### PR TITLE
Fix store state replacement

### DIFF
--- a/src/auth/store.js
+++ b/src/auth/store.js
@@ -15,10 +15,14 @@ const auth = {
 
   mutations: {
     update (state, data) {
-      state = Object.assign({}, defaults, data)
+      Object.keys(state).forEach(index => {
+        state[index] = data[index]
+      })
     },
     clear (state) {
-      state = Object.assign(state, defaults)
+      Object.keys(state).forEach(index => {
+        state[index] = defaults[index]
+      })
     }
   },
 

--- a/src/store/common.js
+++ b/src/store/common.js
@@ -54,7 +54,9 @@ export default {
     },
 
     clear (state) {
-      state = Object.assign({}, defaults)
+      Object.keys(state).forEach(index => {
+        state[index] = defaults[index]
+      })
     }
   },
 


### PR DESCRIPTION
When replacing the store state with simple variable assignment,
the state object **looses its observer** and won't be reactive anymore.

Instead of replacing the whole state, each of the state's properties
should be replaced.

Source: https://github.com/vuejs/vuex/issues/1118